### PR TITLE
Verify child nodes have a getAttribute method before calling it

### DIFF
--- a/packages/slotify/src/slotify.js
+++ b/packages/slotify/src/slotify.js
@@ -169,7 +169,7 @@ export const Slotify = superclass =>
               content = unplacedNodes.filter(n => {
                 if (n.nodeType === Node.TEXT_NODE) {
                   return n;
-                } else if (!n.getAttribute('slot')) {
+                } else if (typeof n.getAttribute === 'function' && !n.getAttribute('slot')) {
                   return n;
                 }
               });


### PR DESCRIPTION
This additional check is needed because not all nodes have the `getAttribute` method (e.g. when `n.nodeType === Node.COMMENT_NODE`). Without checking for the existence of the `getAttribute` method, an exception is thrown which ultimately causes the "Slot Rendering Timeout" error to be thrown.